### PR TITLE
tock testing capabilities interrupt startup fix

### DIFF
--- a/host-testing/src/chip.rs
+++ b/host-testing/src/chip.rs
@@ -71,7 +71,8 @@ impl<'a> kernel::Chip for HostChip<'a> {
     }
 
     fn sleep(&self) {
-        self.irq_must_map(|irq_lower| irq_lower.wait_for_interrupt());
+        let wait_untill = self.systick.get_systick_left();
+        self.irq_must_map(|irq_lower| irq_lower.wait_for_interrupt(wait_untill));
     }
 
     unsafe fn atomic<F, R>(&self, f: F) -> R

--- a/host-testing/src/interrupt.rs
+++ b/host-testing/src/interrupt.rs
@@ -90,6 +90,12 @@ impl LowerHalf {
 
         match interrupt {
             Ok(interrupt) => self.pending.push(interrupt),
+            Err(TryRecvError::Empty) => {
+                if !block {
+                    return;
+                }
+                kernel::debug!("Failed to receive interrupt: {}", TryRecvError::Empty);
+            }
             Err(e) => {
                 kernel::debug!("Failed to receive interrupt: {}", e);
             }

--- a/host-testing/src/main.rs
+++ b/host-testing/src/main.rs
@@ -109,6 +109,7 @@ pub unsafe fn reset_handler() {
         DynamicDeferredCall,
         DynamicDeferredCall::new(dynamic_deferred_call_clients)
     );
+    DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
     let stdin = static_init!(io::Stdin, io::stdin());
     let stdout = static_init!(io::Stdout, io::stdout());

--- a/host-testing/src/main.rs
+++ b/host-testing/src/main.rs
@@ -156,7 +156,7 @@ pub unsafe fn reset_handler() {
             EXTERNAL_PROCESS_CAP,
         ) {
             Ok(p) => PROCESSES[i] = Some(static_init!(process::EmulatedProcess<chip::HostChip>, p)),
-            Err(e) => debug!("Failed to start process #{}: {}", i, e),
+            Err(_) => debug!("Failed to start process #{}: ", i),
         }
     }
 

--- a/host-testing/src/syscall.rs
+++ b/host-testing/src/syscall.rs
@@ -64,8 +64,10 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         _stack_size: usize,
         _state: &mut Self::StoredState,
     ) -> core::result::Result<*const usize, ()> {
-        // Nothing to be done here. libtock-[rs|c] and the host kernel can
-        // handle all the setup.
+        // Do nothing as Unix process will be started on first switch_to_process
+        // This is good place for synchronize libtock-rs startup
+        // Right now this is not needed b/c libtock-rs not require
+        // antyhing special right now
         Ok(stack_pointer as *mut usize)
     }
 
@@ -85,6 +87,8 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         state: &mut Self::StoredState,
         callback: kernel::procs::FunctionCall,
     ) -> core::result::Result<*mut usize, *mut usize> {
+        // Do nothing as Unix process will be started on first
+        // switch_to_process
         state.syscall_ret = common_types::KernelReturn::new_cb(common_types::Callback::new(
             callback.pc,
             callback.argument0,
@@ -109,6 +113,9 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
 
         let return_value: Option<common_types::KernelReturn>;
 
+        // Start application process here when, as this is first
+        // function called by scheduler when switching to app process
+        // for first time
         if !process.was_started() {
             let transport = self.get_transport();
 

--- a/host-testing/src/uart.rs
+++ b/host-testing/src/uart.rs
@@ -68,7 +68,8 @@ impl<'a> Transmit<'a> for UartIO<'a> {
             }
         };
 
-        let ret = match stream.write(tx_data) {
+        let (tx_buf , _) : (&mut [u8], _) = tx_data.split_at_mut(tx_len);
+        let ret = match stream.write(tx_buf) {
             Ok(written) => {
                 if written == tx_len {
                     client.transmitted_buffer(tx_data, tx_len, ReturnCode::SUCCESS);


### PR DESCRIPTION
### Pull Request Overview

Small portion of work to update host testing capabilities in TockOs

### Testing Strategy

I discovered this when starting hello world application from libtock-rs (branch t_emulation)
target/debug/tock-host-testing -a ../libtock-rs/target/debug/examples/hello_world

### TODO or Help Wanted

The UnixProcess start method is still not called

### Documentation Updated


### Formatting

- [ ] Fixed spelling errors by manual investigation
